### PR TITLE
Add support for async await

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/metaplex-foundation/beet-swift",
       "state" : {
-        "branch" : "1.0.4",
-        "revision" : "6c19f5c64f762f755070e108db4a486480cfe6a9"
+        "branch" : "1.0.7",
+        "revision" : "e4708bf28b55ce42727006c1cb7882f069d07bd8"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/metaplex-foundation/metaplex-swift-program-library",
       "state" : {
-        "branch" : "1.2.1",
-        "revision" : "c65173ceab1e5900884478cf37b1850819ef17fa"
+        "branch" : "1.3.0",
+        "revision" : "df7725a3cc56c7c71a989daee780650b45270fab"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Metaplex"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/metaplex-foundation/metaplex-swift-program-library", branch: "1.2.1")
+        .package(url: "https://github.com/metaplex-foundation/metaplex-swift-program-library", branch: "1.3.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -22,7 +22,8 @@ let package = Package(
             name: "Metaplex",
             dependencies: [
                 .product(name: "AuctionHouse", package: "metaplex-swift-program-library"),
-                .product(name: "CandyMachine", package: "metaplex-swift-program-library")
+                .product(name: "CandyMachine", package: "metaplex-swift-program-library"),
+                .product(name: "TokenMetadata", package: "metaplex-swift-program-library")
             ]),
         .testTarget(
             name: "MetaplexTests",

--- a/Sources/Metaplex/Modules/NFTS/NftClient.swift
+++ b/Sources/Metaplex/Modules/NFTS/NftClient.swift
@@ -19,20 +19,60 @@ public class NftClient {
         let operation = FindNftByMintOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: FindNftByMintOperation.pure(.success(mintKey))).run { onComplete($0) }
     }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findByMint(mintKey: PublicKey) async throws -> NFT {
+        try await withCheckedThrowingContinuation { continuation in
+            findByMint(mintKey: mintKey) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     public func findByMetadata(_ metadata: PublicKey, onComplete: @escaping (Result<NFT, OperationError>) -> Void) {
         let operation = FindNftByMetadataOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: FindNftByMetadataOperation.pure(.success(metadata))).run { onComplete($0) }
+    }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findByMetadata(metadata: PublicKey) async throws -> NFT {
+        try await withCheckedThrowingContinuation { continuation in
+            findByMetadata(metadata) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     public func findByToken(address: PublicKey, onComplete: @escaping (Result<NFT, OperationError>) -> Void) {
         let operation = FindNftByTokenOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: FindNftByTokenOperation.pure(.success(address))).run { onComplete($0) }
     }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findByToken(address: PublicKey) async throws -> NFT {
+        try await withCheckedThrowingContinuation { continuation in
+            findByToken(address: address) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     public func findAllByMintList(mintKeys: [PublicKey], onComplete: @escaping (Result<[NFT?], OperationError>) -> Void) {
         let operation = FindNftsByMintListOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: FindNftsByMintListOperation.pure(.success(mintKeys))).run { onComplete($0) }
+    }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findAllByMintList(mintKeys: [PublicKey]) async throws -> [NFT?] {
+        try await withCheckedThrowingContinuation { continuation in
+            findAllByMintList(mintKeys: mintKeys) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     public func findAllByCreator(creator: PublicKey, position: Int? = 1, onComplete: @escaping (Result<[NFT?], OperationError>) -> Void) {
@@ -43,6 +83,16 @@ public class NftClient {
                 position: position
             )))).run { onComplete($0) }
     }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findAllByCreator(creator: PublicKey, position: Int? = 1) async throws -> [NFT?] {
+        try await withCheckedThrowingContinuation { continuation in
+            findAllByCreator(creator: creator, position: position) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     public func findAllByCandyMachine(candyMachine: PublicKey, version: UInt8? = 2, onComplete: @escaping (Result<[NFT?], OperationError>) -> Void) {
         let operation = FindNftsByCandyMachineOnChainOperationHandler(metaplex: self.metaplex)
@@ -52,15 +102,45 @@ public class NftClient {
                 version: version
             )))).run { onComplete($0) }
     }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findAllByCandyMachine(candyMachine: PublicKey, version: UInt8? = 2) async throws -> [NFT?] {
+        try await withCheckedThrowingContinuation { continuation in
+            findAllByCandyMachine(candyMachine: candyMachine, version: version) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     public func findAllByOwner(publicKey: PublicKey, onComplete: @escaping (Result<[NFT?], OperationError>) -> Void) {
         let operation = FindNftsByOwnerOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: FindNftsByOwnerOperation.pure(.success(publicKey))).run { onComplete($0) }
     }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func findAllByOwner(publicKey: PublicKey) async throws -> [NFT?] {
+        try await withCheckedThrowingContinuation { continuation in
+            findAllByOwner(publicKey: publicKey) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     public func createNft(input: CreateNftInput, onComplete: @escaping (Result<NFT, OperationError>) -> Void) {
         let operation = CreateNftOnChainOperationHandler(metaplex: self.metaplex)
         operation.handle(operation: CreateNftOperation.pure(.success(input))).run { onComplete($0) }
+    }
+    
+    @available(macOS 10.15, *)
+    @available(iOS 13.0.0, *)
+    func createNft(input: CreateNftInput) async throws -> NFT {
+        try await withCheckedThrowingContinuation { continuation in
+            createNft(input: input) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     // MARK: - Deprecated

--- a/Tests/MetaplexTests/Drivers/Identity/KeypairIdentityDriverTests.swift
+++ b/Tests/MetaplexTests/Drivers/Identity/KeypairIdentityDriverTests.swift
@@ -19,7 +19,7 @@ final class KeypairIdentityDriverTests: XCTestCase {
     let solanaConnection = SolanaConnectionDriver(endpoint: .mainnetBetaSolana)
     var keypairIdentityDriver: KeypairIdentityDriver!
     
-    override func setUp() async throws {
+    override func setUp() {
         keypairIdentityDriver = KeypairIdentityDriver(solanaRPC: solanaConnection.api, account: account)
     }
     

--- a/Tests/MetaplexTests/Modules/NFTs/Operations/FindNftsByOwnerOnChainOperationHandlerTests.swift
+++ b/Tests/MetaplexTests/Modules/NFTs/Operations/FindNftsByOwnerOnChainOperationHandlerTests.swift
@@ -14,7 +14,7 @@ final class FindNftsByOwnerOnChainOperationHandlerTests: XCTestCase {
     var metaplex: Metaplex!
     
     override func setUpWithError() throws {
-        let solanaConnection = SolanaConnectionDriver(endpoint: .mainnetBetaSolana)
+        let solanaConnection = SolanaConnectionDriver(endpoint: .devnetSolana)
         let solanaIdentityDriver = ReadOnlyIdentityDriver(solanaRPC: solanaConnection.api, publicKey: TEST_PUBLICKEY)
         let storageDriver = MemoryStorageDriver()
         metaplex = Metaplex(connection: solanaConnection, identityDriver: solanaIdentityDriver, storageDriver: storageDriver)
@@ -32,8 +32,8 @@ final class FindNftsByOwnerOnChainOperationHandlerTests: XCTestCase {
         }
         lock.run()
         let nfts = try! result?.get()
-        let nft = nfts!.first { $0!.metadataAccount.mint.base58EncodedString == "71PdnsexRQG92ZcSpEV8nn5XFqPzfK5j86yUWRF5NLyp" }!
-        XCTAssertEqual(nft?.uri, "https://arweave.net/UnB9UYQSwO3rGWSlQkwaiVDfKJOjPopV_IdWSqlLKlo")
-        XCTAssertEqual(nft?.updateAuthority.base58EncodedString, "AVgijgTG4WKDycFwYhqioMreXJpz14no8dbE8EF5roZV")
+        let nft = nfts!.first { $0!.metadataAccount.mint.base58EncodedString == "5quwyoKCi25TmamvqRDi373e1TgypCfnAKFR9h6KwB6G" }!
+        XCTAssertEqual(nft?.uri, "https://arweave.net/8G_jZ4hY-96LGxK9aK1DY2Po6NTjVbiqXM339FuzLFM")
+        XCTAssertEqual(nft?.updateAuthority.base58EncodedString, "ccc9XfyEMh9sU6DRkUmqQGJqgdKb6QyUaaT5h5BGYw4")
     }
 }


### PR DESCRIPTION
…tests

- Update `beet-swift` from `1.0.4` to `1.0.7`
- Update `metaplex-swift-program-library` from `1.2.1` to `1.3.0`
- Add the `TokenMetadata` product to the `Metaplex` target
- Add a test target for the `Metaplex` package

[Tests/MetaplexTests/Drivers/Identity/KeypairIdentityDriverTests.swift]
- Change `setUp()` function to no longer be `async` [Package.resolved]
- Update `beet-swift` from `1.0.4` to `1.0.7`
- Update `metaplex-swift-program-library` from `1.2.1` to `1.3.0` [Package.swift]
- Update the `metaplex-swift-program-library` dependency from `1.2.1` to `1.3.0`
- Add the `TokenMetadata` product to the `Metaplex` target
- Add a test target for the `Metaplex` package